### PR TITLE
Fix for spaces handling in file paths

### DIFF
--- a/releases/shebang-unit
+++ b/releases/shebang-unit
@@ -1137,4 +1137,4 @@ _main__print_api_cheat_sheet_and_exit() {
 }
 
 
-main__main $@
+main__main "$@"

--- a/releases/shebang-unit
+++ b/releases/shebang-unit
@@ -190,16 +190,18 @@ runner__run_all_test_files() {
 
 _runner__run_all_test_files_with_pattern_in_directory() {
   local file
-  local files=($(_runner__get_test_files_in_directory "$1"))
+  local files
+  array__from_lines files <<< "$(_runner__get_test_files_in_directory "$1")"
   for file in "${files[@]}"; do
     file_runner__run_test_file "${file}"
   done
 }
 
 _runner__get_test_files_in_directory() {
-  local files=($(find "$1" -name "${SBU_TEST_FILE_PATTERN}" | sort))
+  local files
+  array__from_lines files <<< "$(find "$1" -name "${SBU_TEST_FILE_PATTERN}" | sort)"
   if [[ "${SBU_RANDOM_RUN}" == "${SBU_YES}"  ]]; then
-    files=($(system__randomize_array "${files[@]}"))
+    array__from_lines files <<< "$(system__randomize_array "${files[@]}")"
   fi
   array__print "${files[@]}"
 }
@@ -902,6 +904,11 @@ array__contains() {
   return ${SBU_FAILURE_STATUS_CODE}
 }
 
+array__from_lines() {
+  local IFS=$'\n'
+  eval "$1=(\$(</dev/stdin))"
+}
+
 array__print() {
   local element
   for element in "$@"; do
@@ -929,7 +936,7 @@ system__randomize_array() {
     local random_index=$(( $(system__random) % ${#copy[@]} ))
     system__print_line "${copy[${random_index}]}"
     unset copy[${random_index}]
-    copy=(${copy[@]})
+    copy=("${copy[@]}")
   done
 }
 

--- a/sources/production/core/runner/runner.sh
+++ b/sources/production/core/runner/runner.sh
@@ -10,16 +10,18 @@ runner__run_all_test_files() {
 
 _runner__run_all_test_files_with_pattern_in_directory() {
   local file
-  local files=($(_runner__get_test_files_in_directory "$1"))
+  local files
+  array__from_lines files <<< "$(_runner__get_test_files_in_directory "$1")"
   for file in "${files[@]}"; do
     file_runner__run_test_file "${file}"
   done
 }
 
 _runner__get_test_files_in_directory() {
-  local files=($(find "$1" -name "${SBU_TEST_FILE_PATTERN}" | sort))
+  local files
+  array__from_lines files <<< "$(find "$1" -name "${SBU_TEST_FILE_PATTERN}" | sort)"
   if [[ "${SBU_RANDOM_RUN}" == "${SBU_YES}"  ]]; then
-    files=($(system__randomize_array "${files[@]}"))
+    array__from_lines files <<< "$(system__randomize_array "${files[@]}")"
   fi
   array__print "${files[@]}"
 }

--- a/sources/production/release.sh
+++ b/sources/production/release.sh
@@ -34,7 +34,7 @@ release__execute_for_each_module() {
 }
 
 _release__append_runner_call_in_release_file() {
-  _release__append_to_release_file 'main__main $@'
+  _release__append_to_release_file 'main__main "$@"'
 }
 
 _release__append_module_to_release_file() {

--- a/sources/production/utils/system.sh
+++ b/sources/production/utils/system.sh
@@ -47,6 +47,11 @@ array__contains() {
   return ${SBU_FAILURE_STATUS_CODE}
 }
 
+array__from_lines() {
+  local IFS=$'\n'
+  eval "$1=(\$(</dev/stdin))"
+}
+
 array__print() {
   local element
   for element in "$@"; do
@@ -74,7 +79,7 @@ system__randomize_array() {
     local random_index=$(( $(system__random) % ${#copy[@]} ))
     system__print_line "${copy[${random_index}]}"
     unset copy[${random_index}]
-    copy=(${copy[@]})
+    copy=("${copy[@]}")
   done
 }
 

--- a/sources/tests/utils/system_test.sh
+++ b/sources/tests/utils/system_test.sh
@@ -134,3 +134,54 @@ can_randomize_array() {
   local actual_as_string="$(system__pretty_print_array "${actual[@]}")"
   assertion__different "${ordred_as_string}" "${actual_as_string}"
 }
+
+randomize_array_preserve_spaces() {
+  local ordered=("a 1" "b 2" "c 3" "d 4" "e 5")
+
+  local actual
+  array__from_lines actual <<< "$(system__randomize_array "${ordered[@]}")"
+
+  assertion__equal 5 "${#actual[@]}"
+  assertion__array_contains "a 1" "${actual[@]}"
+  assertion__array_contains "b 2" "${actual[@]}"
+  assertion__array_contains "c 3" "${actual[@]}"
+  local ordred_as_string="$(system__pretty_print_array "${ordered[@]}")"
+  local actual_as_string="$(system__pretty_print_array "${actual[@]}")"
+  assertion__different "${ordred_as_string}" "${actual_as_string}"
+}
+
+can_get_array_from_lines() {
+  local expected=(1 2)
+  local actual
+  array__from_lines actual <<< "1
+2"
+
+  local expected_as_string="$(system__pretty_print_array "${expected[@]}")"
+  local actual_as_string="$(system__pretty_print_array "${actual[@]}")"
+  assertion__equal "${expected_as_string}" "${actual_as_string}"
+}
+
+getting_array_from_lines_preserve_spaces() {
+  local expected=("1 3" "2 4")
+  local actual
+  array__from_lines actual <<< "1 3
+2 4"
+
+  local expected_as_string="$(system__pretty_print_array "${expected[@]}")"
+  local actual_as_string="$(system__pretty_print_array "${actual[@]}")"
+  assertion__equal "${expected_as_string}" "${actual_as_string}"
+}
+
+can_get_array_from_lines_calling_a_function() {
+  local expected=("plop.sh" "un deux.sh" "test.sh")
+  local actual
+  array__from_lines actual <<< "$(_array)"
+
+  local expected_as_string="$(system__pretty_print_array "${expected[@]}")"
+  local actual_as_string="$(system__pretty_print_array "${actual[@]}")"
+  assertion__equal "${expected_as_string}" "${actual_as_string}"
+}
+
+_array() {
+  printf "plop.sh\nun deux.sh\ntest.sh\n"
+}


### PR DESCRIPTION
Manipulation of arrays of paths broke if they contained spaces (or tabulations). So testing a project with a space in its path failed.

This is fixed by setting IFS (internal field separator) to a single line break on array assignment. It is not perfect as a file path may contain a line break. I wanted to use null characters, but apparently with Bash it is not possible to store them in variables nor to pass them as arguments.

The IFS variable is set locally in `array__from_line`. Its propagation is prevented as it may cause unexpected consequences.

I have a branch with the failing tests [here](https://github.com/PotatoesMaster/shebang-unit/tree/failing-tests).

Also, thanks for your work. :)
